### PR TITLE
Dependabot を導入する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabotは、GitHubなどのコード管理プラットフォームで使用できるオープンソースの依存関係管理ツールです。Dependabotを導入すると、以下のような利点があります。

1. セキュリティの向上：依存関係の脆弱性は、悪意のある攻撃者がシステムに侵入するための侵入経路になる可能性があります。Dependabotは、アプリケーションの依存関係が最新であることを確認することにより、脆弱性のリスクを最小限に抑えることができます。

1. 時間の節約：依存関係のバージョン管理には多くの時間とリソースが必要です。Dependabotを導入することにより、依存関係の最新バージョンを自動的に更新することができます。これにより、開発者は手動で依存関係を更新するために費やす時間を節約することができます。

1. 可能性の向上：開発者は、常に最新の依存関係を使用することにより、新しい機能を利用できるようになります。これにより、アプリケーションの機能性が向上し、最新の技術を活用することができます。

1. 透明性の向上：依存関係の更新は、複雑な手順を必要とする場合があります。Dependabotを導入することにより、依存関係の更新に関する情報が透明化され、開発者はどの依存関係が更新されたかを把握しやすくなります。

以上のような利点から、Dependabotを導入することは、アプリケーションの安全性と信頼性を向上させるために非常に有用です。