### PR TITLE
🤫 ノートの出力を制限

### DIFF
--- a/kaggle-notebooks/notebooks/titanic.ipynb
+++ b/kaggle-notebooks/notebooks/titanic.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!kaggle competitions download -c titanic"
+    "!kaggle competitions download -c titanic --quiet"
    ]
   },
   {

--- a/kaggle-notebooks/notebooks/titanic.ipynb
+++ b/kaggle-notebooks/notebooks/titanic.ipynb
@@ -56,7 +56,7 @@
    "source": [
     "import polars as pl\n",
     "train = pl.read_csv(\"train.csv\")\n",
-    "train"
+    "train.head(3)"
    ]
   }
  ],

--- a/kaggle-notebooks/notebooks/titanic.md
+++ b/kaggle-notebooks/notebooks/titanic.md
@@ -30,5 +30,5 @@ Titanicのデータをダウンロードします。
 ```{code-cell}
 import polars as pl
 train = pl.read_csv("train.csv")
-train
+train.head(3)
 ```

--- a/kaggle-notebooks/notebooks/titanic.md
+++ b/kaggle-notebooks/notebooks/titanic.md
@@ -15,7 +15,7 @@ jupytext:
 Titanicのデータをダウンロードします。
 
 ```{code-cell}
-!kaggle competitions download -c titanic
+!kaggle competitions download -c titanic --quiet
 ```
 
 ダウンロードの際には`kaggle.json`ファイルを `~/.kaggle/kaggle.json` に配置しておく必要があります。


### PR DESCRIPTION
- 🤫 kaggleコマンドのプログレスバーを出力しない
- 🤫 trainデータの表示を3データまでに制限